### PR TITLE
Feat: private toggle permission for private contributions

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,7 +25,8 @@ if username and token and button_pressed:
         st.error("Error fetching data. Check your username/token.")
     else:
         user_stats = process_user_data(raw_data)
-        formatted_date = datetime.strptime(user_stats['created_at'], "%Y-%m-%dT%H:%M:%SZ").strftime("%d-%m-%Y")
+        formatted_date = user_stats.get("formatted_date")
+
         joined_since = user_stats.get("joined_since")
         github_days = user_stats.get("github_days")
         active_days = user_stats.get("active_days")

--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 import streamlit as st
 import pandas as pd
 from datetime import datetime
-from github_stats import fetch_contribution_data, process_contribution_data, process_language_data
+from github_stats import fetch_contribution_data, process_contribution_data, process_language_data, process_user_data
 import matplotlib.pyplot as plt
 
 st.set_page_config(
@@ -24,6 +24,32 @@ if username and token and button_pressed:
     if "errors" in raw_data:
         st.error("Error fetching data. Check your username/token.")
     else:
+        user_stats = process_user_data(raw_data)
+        formatted_date = datetime.strptime(user_stats['created_at'], "%Y-%m-%dT%H:%M:%SZ").strftime("%d-%m-%Y")
+        joined_since = user_stats.get("joined_since")
+        github_days = user_stats.get("github_days")
+        active_days = user_stats.get("active_days")
+        less_than_2_months_old = user_stats.get("less_than_2_months_old")
+        
+        st.header("User Stats")
+        with st.container():
+            col1, col2 = st.columns(2)
+            col1.metric(
+                label="Joined Github since",
+                value= formatted_date,
+                delta= joined_since,
+                delta_color= "inverse" if less_than_2_months_old else "normal",
+                border= True
+            )
+
+            col2.metric(
+                label="Total days on GitHub",
+                value= f"{github_days} days",
+                delta= f"Active for: {active_days} days",
+                delta_color= "off" if active_days < 7 else "normal",
+                border= True
+            )
+
         stats = process_contribution_data(raw_data)
 
         # Display summary metrics

--- a/app.py
+++ b/app.py
@@ -158,36 +158,59 @@ if username and token and button_pressed:
         # Custom Achievements (based on visible contributions)
         st.header("Achievements")
         with st.container(border=True):
-            if stats['current_streak'] <= 2:
-                st.markdown("🌱 **Streak Beginner**") 
-            elif stats['current_streak'] > 2 and stats['current_streak'] <= 7:
-                st.markdown("🌿 **Streak Novice**")
-            elif stats['current_streak'] > 7 and stats['current_streak'] <= 14:
-                st.markdown("🌳 **Streak Apprentice**") 
-            elif stats['current_streak'] > 14 and stats['current_streak'] <= 30:
-                st.markdown("⚔️ **Streak Journeyman**")
-            elif stats['current_streak'] > 30 and stats['current_streak'] <= 60:
-                st.markdown("🛡️ **Streak Expert**")
-            elif stats['current_streak'] > 60 and stats['current_streak'] <= 90:
-                st.markdown("🧙‍♂️ **Streak Master**")
-            elif stats['current_streak'] > 90:
-                st.markdown("🐉 **Streak Legend**") 
+            # Define achievements with their criteria and thresholds
+            streak_achievements = {
+                "Streak Beginner": {"required": 2, "criteria": "Made contributions for 2 consecutive days"},
+                "Streak Novice": {"required": 7, "criteria": "Made contributions for 7 consecutive days"},
+                "Streak Apprentice": {"required": 14, "criteria": "Made contributions for 14 consecutive days"},
+                "Streak Journeyman": {"required": 30, "criteria": "Made contributions for 30 consecutive days"},
+                "Streak Expert": {"required": 60, "criteria": "Made contributions for 60 consecutive days"},
+                "Streak Master": {"required": 90, "criteria": "Made contributions for 90 consecutive days"},
+                "Streak Legend": {"required": 120, "criteria": "Made contributions for 120+ consecutive days"}
+            }
 
+            contribution_achievements = {
+                "Contributor": {"required": 50, "criteria": "Made your first 50 contributions"},
+                "Regular Contributor": {"required": 100, "criteria": "Reached 100 total contributions"},
+                "Active Contributor": {"required": 500, "criteria": "Reached 500 total contributions"},
+                "Dedicated Contributor": {"required": 1000, "criteria": "Reached 1,000 total contributions"},
+                "Seasoned Contributor": {"required": 5000, "criteria": "Reached 5,000 total contributions"},
+                "GitHub Legend": {"required": 10000, "criteria": "Reached 10,000+ total contributions"}
+            }
+
+            # Display Streak Achievements
+            st.subheader("🔥 Streak Achievements")
+            current_streak = stats['current_streak']
             
-            if display_total < 50:
-                st.markdown("🌱 **Contributor**")
-            elif display_total >= 50 and display_total < 100:
-                st.markdown("🌿 **Regular Contributor**")
-            elif display_total >= 100 and display_total < 500:
-                st.markdown("🌳 **Active Contributor**")
-            elif display_total >= 500 and display_total < 1000:
-                st.markdown("⚔️ **Dedicated Contributor**")
-            elif display_total >= 1000 and display_total < 5000:
-                st.markdown("🛡️ **Seasoned Contributor**")
-            elif display_total >= 5000:
-                st.markdown("🧙‍♂️ **GitHub Legend**")
+            for title, details in streak_achievements.items():
+                progress = min(100, (current_streak / details["required"]) * 100)
+                if current_streak >= details["required"]:
+                    emoji = "✅"
+                    st.markdown(f"{emoji} **{title}** – {details['criteria']}")
+                else:
+                    emoji = "🔒"
+                    col1, col2 = st.columns([3, 1])
+                    col1.markdown(f"{emoji} **{title}** – {details['criteria']}")
+                    col2.markdown(f"Progress: {progress:.1f}%")
+                    if progress > 0:
+                        st.progress(progress / 100, text="")
 
-            st.write("Keep growing your GitHub stats and unlock more achievements!")
+            # Display Contribution Achievements
+            st.subheader("🏆 Contribution Achievements")
+            for title, details in contribution_achievements.items():
+                progress = min(100, (display_total / details["required"]) * 100)
+                if display_total >= details["required"]:
+                    emoji = "✅"
+                    st.markdown(f"{emoji} **{title}** – {details['criteria']}")
+                else:
+                    emoji = "🔒"
+                    col1, col2 = st.columns([3, 1])
+                    col1.markdown(f"{emoji} **{title}** – {details['criteria']}")
+                    col2.markdown(f"Progress: {progress:.1f}%")
+                    if progress > 0:
+                        st.progress(progress / 100, text="")
+
+            st.info("Keep growing your GitHub stats to unlock more achievements! 🚀", icon="💪")
 
         # Add Language Distribution
         st.header("Programming Languages")

--- a/app.py
+++ b/app.py
@@ -14,6 +14,12 @@ st.title("GitHub Contribution Tracker")
 with st.container(border=True):
     username = st.text_input("Enter GitHub Username:")
     token = st.text_input("Enter GitHub Personal Access Token:", type="password", help="Help: [Create Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)")
+    show_private = st.toggle("Show Private Contributions", value=True, help="Toggle to show/hide private contributions in stats. Requires a token with 'repo' scope.")
+    
+    # Add warning about token permissions if showing private contributions
+    if show_private:
+        st.info("⚠️ To view private contributions, make sure your token has the 'repo' scope enabled.", icon="ℹ️")
+    
     button_pressed = st.button("Track", type="primary")
 
 color = "#26a641"
@@ -52,16 +58,27 @@ if username and token and button_pressed:
             )
 
         stats = process_contribution_data(raw_data)
+        
+        # Validate contribution data
+        if stats.get('public_contributions', 0) == 0 and stats.get('private_contributions', 0) == 0:
+            st.warning("No contributions found. If you have private repositories, make sure your token has the 'repo' scope.")
+        
+        # Calculate contributions based on toggle
+        display_total = stats.get('public_contributions', 0)
+        if show_private:
+            display_total += stats.get('private_contributions', 0)
+            if stats.get('private_contributions', 0) == 0:
+                st.info("No private contributions found. If you have private repositories, verify your token permissions.")
 
         # Display summary metrics
         st.header("Summary Stats")
         with st.container(border=True):
-            col1, col2 = st.columns(2)
+            col1, col2, col3 = st.columns(3)
             col1.metric(
                 "Total Contributions", 
-                value= f"{stats['total_contributions']} commits",
-                delta=f"Highest in a day: {stats['highest_contribution']} commits",
-                delta_color= "off" if stats['highest_contribution'] == 0 else "normal"
+                value= f"{display_total:,} commits",  # Add thousands separator
+                delta=f"Public: {stats['public_contributions']:,}" + (f" | Private: {stats['private_contributions']:,}" if show_private else ""),
+                delta_color= "off" if display_total == 0 else "normal"
                 )
             col2.metric(
                 "Longest Streak", 
@@ -69,62 +86,76 @@ if username and token and button_pressed:
                 delta=f"Current Streak: {stats['current_streak']} days",
                 delta_color= "off" if stats['current_streak'] == 0 else "normal"
                 )
+            col3.metric(
+                "Highest in a Day",
+                value= f"{stats['highest_contribution']} commits",
+                delta="Public" + (" + Private" if show_private else ""),
+                delta_color="off"
+                )
 
         # Prepare data for visualizations
-        days = stats["days"]
-        dates = [datetime.strptime(day["date"], "%Y-%m-%d") for day in days]
-        contributions = [day["contributionCount"] for day in days]
+        days = stats.get("days", [])
+        if not days:
+            st.warning("No contribution data available for visualizations.")
+        else:
+            dates = [datetime.strptime(day["date"], "%Y-%m-%d") for day in days]
+            # Calculate the average daily private contributions to distribute them across days
+            daily_private_ratio = (stats.get('private_contributions', 0) / len(days)) if len(days) > 0 and show_private else 0
+            # Add private contributions to daily counts if enabled
+            contributions = [day.get("contributionCount", 0) + daily_private_ratio for day in days]
 
-        # Contributions Over Time
-        st.header("Contributions Over Time")
-        with st.container(border=True):
-            chart_data = pd.DataFrame({"Date": dates, "Contributions": contributions})
-            st.line_chart(chart_data.set_index("Date"), x_label="Date", y_label="Contributions", color=color)
+            # Contributions Over Time
+            st.header("Contributions Over Time")
+            with st.container(border=True):
+                chart_data = pd.DataFrame({"Date": dates, "Contributions": contributions})
+                st.line_chart(
+                    chart_data.set_index("Date"), 
+                    x_label="Date", 
+                    y_label=f"Contributions ({'Public + Private' if show_private else 'Public'})", 
+                    color=color
+                )
 
-        # Yearly Growth
-        chart_data['Year'] = chart_data['Date'].dt.year
-        yearly_contributions = chart_data.groupby('Year')['Contributions'].sum()
+                # Add note about private contributions distribution
+                if show_private and stats.get('private_contributions', 0) > 0:
+                    st.caption("Note: Private contributions are distributed evenly across the time period as detailed daily data is not available.")
 
-        st.header("Yearly Growth")
-        with st.container(border=True):
-            st.bar_chart(yearly_contributions, color=color)
+            # Yearly Growth
+            chart_data['Year'] = chart_data['Date'].dt.year
+            yearly_contributions = chart_data.groupby('Year')['Contributions'].sum().round(1)  # Round to 1 decimal
 
-        # Weekly Heatmap
-        # st.header("Weekly Contribution Heatmap")
-        chart_data["Week"] = chart_data['Date'].dt.isocalendar().week
-        chart_data["Day"] = chart_data['Date'].dt.dayofweek
+            st.header(f"Yearly Growth ({'Public + Private' if show_private else 'Public'})")
+            with st.container(border=True):
+                st.bar_chart(yearly_contributions, color=color)
 
-        # heatmap_data = chart_data.pivot_table(index="Day", columns="Week", values="Contributions", aggfunc="sum", fill_value=0)
-        # st.write("**Heatmap (Day of Week vs. Week of Year)**")
-        # st.dataframe(heatmap_data, use_container_width=True)
-
-        # Most Productive Days
-        st.header("Most Productive Day")
-        most_productive_day = chart_data.loc[chart_data['Contributions'].idxmax()]
-        st.metric(
-            "Date", 
-            most_productive_day['Date'].strftime("%d-%m-%Y"), 
-            delta=f"{most_productive_day['Contributions']} Contributions", 
-            label_visibility="collapsed", 
-            border=True
+            # Most Productive Days
+            st.header("Most Productive Day")
+            most_productive_day = chart_data.loc[chart_data['Contributions'].idxmax()]
+            st.metric(
+                "Date", 
+                most_productive_day['Date'].strftime("%d-%m-%Y"), 
+                delta=f"{most_productive_day['Contributions']:.1f} Contributions ({'Public + Private' if show_private else 'Public'})", 
+                label_visibility="collapsed", 
+                border=True
             )
 
-        # Weekday vs. Weekend Contributions
-        st.header("Weekday vs. Weekend Contributions")
-        with st.container(border=True):
-            chart_data['IsWeekend'] = chart_data['Date'].dt.dayofweek >= 5
-            weekend_data = chart_data.groupby('IsWeekend')['Contributions'].sum()
-            weekend_data.index = ["Weekdays", "Weekends"]
-            st.bar_chart(weekend_data, color=color, horizontal=True)
+            # Weekday vs. Weekend Contributions
+            st.header(f"Weekday vs. Weekend Contributions ({'Public + Private' if show_private else 'Public'})")
+            with st.container(border=True):
+                chart_data['IsWeekend'] = chart_data['Date'].dt.dayofweek >= 5
+                weekend_data = chart_data.groupby('IsWeekend')['Contributions'].sum().round(1)
+                weekend_data.index = ["Weekdays", "Weekends"]
+                st.bar_chart(weekend_data, color=color, horizontal=True)
 
-        # Contribution Times Analysis (if available)
-        st.header("Contributions by Day of Week")
-        with st.container(border=True):
-            day_of_week_data = chart_data.groupby("Day")['Contributions'].sum()
-            day_of_week_data.index = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
-            st.bar_chart(day_of_week_data, color=color, horizontal=True)
+            # Contributions by Day of Week
+            st.header(f"Contributions by Day of Week ({'Public + Private' if show_private else 'Public'})")
+            with st.container(border=True):
+                # Add the Day column before grouping
+                chart_data['Day'] = chart_data['Date'].dt.dayofweek
+                day_of_week_data = chart_data.groupby("Day")['Contributions'].sum().round(1)
+                day_of_week_data.index = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+                st.bar_chart(day_of_week_data, color=color, horizontal=True)
 
-        # Custom Achievements
+        # Custom Achievements (based on visible contributions)
         st.header("Achievements")
         with st.container(border=True):
             if stats['current_streak'] <= 2:
@@ -143,17 +174,17 @@ if username and token and button_pressed:
                 st.markdown("🐉 **Streak Legend**") 
 
             
-            if stats['total_contributions'] < 50:
+            if display_total < 50:
                 st.markdown("🌱 **Contributor**")
-            elif stats['total_contributions'] >= 50 and stats['total_contributions'] < 100:
+            elif display_total >= 50 and display_total < 100:
                 st.markdown("🌿 **Regular Contributor**")
-            elif stats['total_contributions'] >= 100 and stats['total_contributions'] < 500:
+            elif display_total >= 100 and display_total < 500:
                 st.markdown("🌳 **Active Contributor**")
-            elif stats['total_contributions'] >= 500 and stats['total_contributions'] < 1000:
+            elif display_total >= 500 and display_total < 1000:
                 st.markdown("⚔️ **Dedicated Contributor**")
-            elif stats['total_contributions'] >= 1000 and stats['total_contributions'] < 5000:
+            elif display_total >= 1000 and display_total < 5000:
                 st.markdown("🛡️ **Seasoned Contributor**")
-            elif stats['total_contributions'] >= 5000:
+            elif display_total >= 5000:
                 st.markdown("🧙‍♂️ **GitHub Legend**")
 
             st.write("Keep growing your GitHub stats and unlock more achievements!")

--- a/github_stats.py
+++ b/github_stats.py
@@ -1,6 +1,7 @@
 import requests
 from datetime import datetime
-from util import format_duration, is_less_than_2_months_old
+from util import format_duration, is_less_than_2_months_old, format_date
+
 
 def fetch_contribution_data(username, token):
     url = "https://api.github.com/graphql"
@@ -100,6 +101,8 @@ def process_user_data(data):
     
     # Calculate total GitHub days
     created_at = user_data.get("createdAt")
+    formatted_date = format_date(user_data.get("createdAt")) 
+
     less_than_2_months_old = is_less_than_2_months_old(created_at)
     github_days = (datetime.now() - datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%SZ")).days
 
@@ -113,6 +116,7 @@ def process_user_data(data):
     
     return {
         "created_at": created_at,
+        "formatted_date": formatted_date,
         "joined_since": joined_since,
         "github_days": github_days,
         "active_days": active_days,

--- a/util.py
+++ b/util.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+def format_duration(iso_date):
+    created_at = datetime.strptime(iso_date, "%Y-%m-%dT%H:%M:%SZ")
+    now = datetime.now()
+    delta = now - created_at
+
+    years = delta.days // 365
+    months = (delta.days % 365) // 30
+    days = (delta.days % 365) % 30
+
+    parts = []
+    if years:
+        parts.append(f"{years} year{'s' if years > 1 else ''}")
+    if months:
+        parts.append(f"{months} month{'s' if months > 1 else ''}")
+    if days:
+        parts.append(f"{days} day{'s' if days > 1 else ''}")
+
+    return " ".join(parts) if parts else "0 days"
+
+def is_less_than_2_months_old(iso_date):
+    created_date = datetime.strptime(iso_date, "%Y-%m-%dT%H:%M:%SZ")
+    two_months_ago = datetime.now() - relativedelta(months=2)
+    return created_date > two_months_ago

--- a/util.py
+++ b/util.py
@@ -24,3 +24,7 @@ def is_less_than_2_months_old(iso_date):
     created_date = datetime.strptime(iso_date, "%Y-%m-%dT%H:%M:%SZ")
     two_months_ago = datetime.now() - relativedelta(months=2)
     return created_date > two_months_ago
+
+def format_date(iso_date):
+    dt = datetime.strptime(iso_date, "%Y-%m-%dT%H:%M:%SZ")
+    return dt.strftime("%B {day}, %Y").replace("{day}", str(dt.day) + ("st" if dt.day in [1, 21, 31] else "nd" if dt.day == 2 else "rd" if dt.day == 3 else "th"))


### PR DESCRIPTION
1. Added better error handling in `github_stats.py`:

- Safe data access with fallbacks to 0
- Type validation for contribution counts
- Better error handling for streaks calculation
- Proper error return values

2. Improved the UI in app.py:

- Added info message about token permissions when private 
- contributions are enabled
- Added warning if no contributions are found
- Added info message if no private contributions are found when enabled
- Added thousands separators to large numbers
- Added proper rounding for decimal values

3. Enhanced visualizations:

- Added check for empty contribution data
- Added explanatory note about private contributions distribution
- Improved error handling for missing data
- Added proper rounding for all numerical displays
- Updated all chart headers to indicate public/private status
- Removed commented-out heatmap code for clarity

4. Added data validation:

- Safe access to all dictionary values with fallbacks
- Proper handling of missing or invalid contribution counts
- Better error messages for various scenarios
- The toggle should now work reliably with:
- Clear user feedback about token permissions
- Proper handling of missing or invalid data
- Consistent display of public/private status across all visualizations
- Better formatting of numbers and dates
- Informative messages about data availability

Please let me know if it works on your end. Praying.