### PR TITLE
(all-in-one); latest: Inspect argument for start-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,0 @@
-__pycache__
-.venv
-test.py 
-data.json
-.streamlit/secrets.toml

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -4,3 +4,6 @@ showSidebarNavigation = false
 [theme]
 base = "dark"
 primaryColor = "#26a641"
+
+[server]
+headless = true

--- a/README.md
+++ b/README.md
@@ -84,9 +84,24 @@ GitHub Contribution Tracker is a **Streamlit** web application that visualizes G
 
 3. Run the app:
 
-   ```bash
-   streamlit run app.py
-   ```
+    <br>
+
+    To run a version with your stats loaded automatically*:
+    
+    ```bash
+    streamlit run app.py
+    ```
+    _*You need to fill out your credentials to secrets file (see below)_
+
+    <br>
+
+    To run an empty version:
+    
+    ```bash
+    streamlit run app.py -- inspect
+    ```  
+
+    <br>  
 
 4. Open your browser and navigate to the URL shown in the terminal (usually `http://localhost:8501`).
 
@@ -94,15 +109,15 @@ GitHub Contribution Tracker is a **Streamlit** web application that visualizes G
 
 ## Usage
 
-1. Enter your credentials into `.stremlit/secrets.toml`.
+1. Enter your credentials into either `.stremlit/secrets.toml` (in repo root), or to system streamlit file, on Win11 it's in `C:\Users\{USER}\.streamlit`, Linux `/home/{USER}/.steamlit`.
 2. Provide a **GitHub Personal Access Token** (with `read:user` and `repo` scopes for GraphQL API access), your **GitHub username**, and set **autoload** to `true` or `false` _(`true` recommended)_.
 
-  `secrets.toml` example:
-  ```
-  token = "github_pat_..."
-  username = "my-github-username"
-  autoload = true
-  ```
+    `secrets.toml` example:
+    ```
+    token = "github_pat_..."
+    username = "my-github-username"
+    autoload = true
+    ```
 
 3. View detailed stats, visualizations, and achievements based on your contribution data.
 
@@ -110,11 +125,10 @@ GitHub Contribution Tracker is a **Streamlit** web application that visualizes G
 
 If you don't want your browser to automatically open the dashboard everytime you run `streamlit run app.py`, just add the following two lines to your `config.toml` in `.streamlit` folder:
 
-```
-[server]
-headless = true
-```
-
+  ```
+  [server]
+  headless = true
+  ```
 ### How to Generate a GitHub Personal Access Token
 
 1. Go to [GitHub Developer Settings](https://github.com/settings/tokens).

--- a/README.md
+++ b/README.md
@@ -94,9 +94,26 @@ GitHub Contribution Tracker is a **Streamlit** web application that visualizes G
 
 ## Usage
 
-1. Enter your **GitHub Username**.
-2. Provide a **GitHub Personal Access Token** (with `read:user` and `repo` scopes for GraphQL API access).
+1. Enter your credentials into `.stremlit/secrets.toml`.
+2. Provide a **GitHub Personal Access Token** (with `read:user` and `repo` scopes for GraphQL API access), your **GitHub username**, and set **autoload** to `true` or `false` _(`true` recommended)_.
+
+  `secrets.toml` example:
+  ```
+  token = "github_pat_..."
+  username = "my-github-username"
+  autoload = true
+  ```
+
 3. View detailed stats, visualizations, and achievements based on your contribution data.
+
+### Control browser auto-open via server config 
+
+If you don't want your browser to automatically open the dashboard everytime you run `streamlit run app.py`, just add the following two lines to your `config.toml` in `.streamlit` folder:
+
+```
+[server]
+headless = true
+```
 
 ### How to Generate a GitHub Personal Access Token
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ GitHub Contribution Tracker is a **Streamlit** web application that visualizes G
 2. Provide a **GitHub Personal Access Token** (with `read:user` and `repo` scopes for GraphQL API access).
 3. View detailed stats, visualizations, and achievements based on your contribution data.
 
+### Control browser auto-open via server config 
+
+If you don't want your browser to automatically open the dashboard everytime you run `streamlit run app.py`, just add the following two lines to your `config.toml` in `.streamlit` folder:
+
+```
+[server]
+headless = true
+```
+
 ### How to Generate a GitHub Personal Access Token
 
 1. Go to [GitHub Developer Settings](https://github.com/settings/tokens).

--- a/utils/process_github_data.py
+++ b/utils/process_github_data.py
@@ -17,10 +17,10 @@ def process_contribution_data(data: dict):
         days = [day for week in calendar['weeks'] for day in week['contributionDays']]
         weeks = calendar.get("weeks", [])
         
-        # Safely get contribution counts with fallbacks to 0
-        public_contributions = calendar.get('totalContributions', 0)
+        # GitHub GraphQL returns contributionCalendar.totalContributions as combined public + restricted counts.
+        total_contributions = calendar.get('totalContributions', 0)
         private_contributions = contributions_collection.get('restrictedContributionsCount', 0)
-        total_contributions = public_contributions + private_contributions
+        public_contributions = max(total_contributions - private_contributions, 0)
             
         # Calculate highest contribution
         highest_contribution, highest_contribution_date = get_highest_contribution(days)

--- a/utils/streamlit_ui.py
+++ b/utils/streamlit_ui.py
@@ -1,12 +1,16 @@
+import sys
 import streamlit as st
 from streamlit import session_state as sst
 from utils.fetch_github_data import fetch_star_count
+
+# CLI argument support for inspect mode
+INSPECT_MODE = "--inspect" in sys.argv or "inspect" in sys.argv
 
 # Read secrets with fallback for local/dev usage.
 # Keep `token` required in deployed environments.
 TOKEN = st.secrets.get("token", "") if hasattr(st, "secrets") else ""
 DEFAULT_USERNAME = st.secrets.get("username", "") if hasattr(st, "secrets") else ""
-AUTOLOAD = st.secrets.get("autoload", False) if hasattr(st, "secrets") else False
+AUTOLOAD = (st.secrets.get("autoload", False) if hasattr(st, "secrets") else False) and not INSPECT_MODE
 
 def base_ui():
     """
@@ -28,17 +32,30 @@ def base_ui():
     # Title and input
     title_bar()
 
-    with st.sidebar.expander("Controls", expanded=not AUTOLOAD):
-        form() # Streamlit Form
+    if INSPECT_MODE:
+        # DEBUG mode: keep sidebar fully visible and inspect flow explicit
+        with st.sidebar:
+            form()
 
-        if AUTOLOAD and sst.username and sst.token:
-            sst.button_pressed = True
+            # autoload intentionally disabled in inspect mode
+            if sst.username and sst.token and sst.button_pressed:
+                nav_ui()
 
-        if sst.username and sst.token and sst.button_pressed:
-            nav_ui() # Sidebar navigation menu
+            promo()
+    else:
+        # normal mode starts collapsed, whether or not autoload is configured,
+        # because the app should not show the controls by default.
+        with st.sidebar.expander("Controls", expanded=False):
+            form() # Streamlit Form
 
-        # how_to_use()
-        promo()
+            if AUTOLOAD and sst.username and sst.token:
+                sst.button_pressed = True
+
+            if sst.username and sst.token and sst.button_pressed:
+                nav_ui() # Sidebar navigation menu
+
+            # how_to_use()
+            promo()
 
 
 def page_config():
@@ -92,9 +109,14 @@ def initialize_sst():
     if 'token' not in sst:
         sst.token = TOKEN
 
-    # If we have a username in secrets, prefill the input and mark the button state
-    if DEFAULT_USERNAME and not sst.username:
-        sst.username = DEFAULT_USERNAME
+    # If inspect mode is enabled, keep username empty for backend steps
+    if INSPECT_MODE:
+        sst.username = ""
+    else:
+        # If we have a username in secrets, prefill the input and mark the button state
+        if DEFAULT_USERNAME and not sst.username:
+            sst.username = DEFAULT_USERNAME
+
     # If a token is present in secrets and user has not manually provided one, use it
     if TOKEN and not sst.user_token:
         sst.user_token = TOKEN

--- a/utils/streamlit_ui.py
+++ b/utils/streamlit_ui.py
@@ -6,6 +6,7 @@ from utils.fetch_github_data import fetch_star_count
 # Keep `token` required in deployed environments.
 TOKEN = st.secrets.get("token", "") if hasattr(st, "secrets") else ""
 DEFAULT_USERNAME = st.secrets.get("username", "") if hasattr(st, "secrets") else ""
+AUTOLOAD = st.secrets.get("autoload", False) if hasattr(st, "secrets") else False
 
 def base_ui():
     """
@@ -27,8 +28,11 @@ def base_ui():
     # Title and input
     title_bar()
 
-    with st.sidebar:
+    with st.sidebar.expander("Controls", expanded=not AUTOLOAD):
         form() # Streamlit Form
+
+        if AUTOLOAD and sst.username and sst.token:
+            sst.button_pressed = True
 
         if sst.username and sst.token and sst.button_pressed:
             nav_ui() # Sidebar navigation menu

--- a/utils/streamlit_ui.py
+++ b/utils/streamlit_ui.py
@@ -2,7 +2,10 @@ import streamlit as st
 from streamlit import session_state as sst
 from utils.fetch_github_data import fetch_star_count
 
-TOKEN = st.secrets["token"]
+# Read secrets with fallback for local/dev usage.
+# Keep `token` required in deployed environments.
+TOKEN = st.secrets.get("token", "") if hasattr(st, "secrets") else ""
+DEFAULT_USERNAME = st.secrets.get("username", "") if hasattr(st, "secrets") else ""
 
 def base_ui():
     """
@@ -75,13 +78,25 @@ def initialize_sst():
 
     # Initializing session state
     if 'username' not in sst:
-        sst.username = ''
+        sst.username = DEFAULT_USERNAME
     if 'user_token' not in sst:
         sst.user_token = ''
     if 'token_present' not in sst:
         sst.token_present = False
     if 'button_pressed' not in sst:
         sst.button_pressed = False
+    if 'token' not in sst:
+        sst.token = TOKEN
+
+    # If we have a username in secrets, prefill the input and mark the button state
+    if DEFAULT_USERNAME and not sst.username:
+        sst.username = DEFAULT_USERNAME
+    # If a token is present in secrets and user has not manually provided one, use it
+    if TOKEN and not sst.user_token:
+        sst.user_token = TOKEN
+        sst.token = TOKEN
+        sst.token_present = False
+
 
 def title_bar():
     """


### PR DESCRIPTION
Here is the whole chunk, also with `-- inspect` argument we discussed in #55

**Supported start-up arguments:**

`streamlit run app.py`
* checks your own stats (backend passes your creds from secrets.toml)

`streamlit run app.py -- inspect`
* start server in inspect mode, so user can view stats of any GitHub user. It's not auto-opened in default browser

`streamlit run app.py --server.headless false -- inspect`
* opens dashboard in default browser in inspect mode, so user can view stats of any GitHub user