### PR TITLE
ENHANCEMENT: "Contributions Over Time" graph

### DIFF
--- a/app.py
+++ b/app.py
@@ -150,12 +150,41 @@ def main():
                 st.markdown("### Contributions Over Time")
                 with st.container(border=True):
                     chart_data = pd.DataFrame({"Date": dates, "Contributions": contributions})
-                    st.line_chart(
-                        chart_data.set_index("Date"), 
-                        x_label="Date", 
-                        y_label=f"Contributions", 
-                        color=color
+                    max_contrib = int(chart_data.Contributions.max() if not chart_data.empty else 1)
+                    fig = go.Figure()
+                    fig.add_trace(go.Scatter(
+                        x=chart_data["Date"],
+                        y=chart_data["Contributions"],
+                        mode="lines+markers",
+                        name="Contributions",
+                        line=dict(color=color)
+                    ))
+
+                    fig.update_layout(
+                        xaxis_title="Time Range",
+                        yaxis_title="Contribution Count",
+                        yaxis=dict(rangemode="tozero", autorange=True, tick0=0),
+                        xaxis=dict(rangeslider=dict(visible=True), type="date"),
+                        margin=dict(l=30, r=20, t=30, b=30),
+                        hovermode="x unified",
+                        template="plotly_white"
                     )
+
+                    fig.update_yaxes(
+                        range=[0, max_contrib * 1.1 if max_contrib > 0 else 1], 
+                        fixedrange=True,
+                        autorange=True,
+                        rangemode="tozero",
+                    )
+                    fig.update_xaxes(
+                        fixedrange=False,
+                        rangeslider=dict(visible=True),
+                        type="date",
+                        constrain="range",
+                    )
+                    fig.update_layout(dragmode='zoom')
+
+                    st.plotly_chart(fig, width='stretch', config={"scrollZoom": True})
 
                 # --- Growth and Statistics ---
 


### PR DESCRIPTION
We thought we shared this one with you as well...

## This is a major improvement to _Contributions Over Time_ graph

Behaviour before:

https://github.com/user-attachments/assets/47c2f839-cd2f-4b54-b3b5-1df1a0d0fd0f

Behaviour after:


https://github.com/user-attachments/assets/8166add0-313d-4f53-b9d9-b8f1e25a8465


### SOLVES:
- allowed display of negative values on `y` axis
- allowed zoom of both `x` and `y` when scrolling → now `x` only
- inability to properly browse through `x` axis → there are two easy ways now
- free movement on `y` axis
- and more...

### NOTES:
- mergeable with your `main`, also with our previous PR's

### KNOWN BUGS:
- not really a bug, but the "Time Range" text at the bottom is a bit clipped (just noticed). To be fixed.