### PR TITLE
feat: Shows stats data from account creation date

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,8 +38,8 @@ def main():
                     followers = user_stats.get("followers")
                     following = user_stats.get("following")
                     repositories = user_stats.get("repositories")
-                    total_prs = user_stats.get("total_pullrequests")
-                    total_issues = user_stats.get("total_issues")
+                    total_prs = cont_stats.get("total_pullrequests")
+                    total_issues = cont_stats.get("total_issues")
                     created_at = datetime.strptime(user_stats.get("created_at"), "%Y-%m-%dT%H:%M:%SZ")
                     created_at = created_at.strftime("%Y-%m-%d")
 

--- a/utils/fetch_github_data.py
+++ b/utils/fetch_github_data.py
@@ -1,5 +1,6 @@
 import requests
 import streamlit as st
+from datetime import datetime
 
 BASE_URL = "https://api.github.com/graphql"
 
@@ -131,41 +132,71 @@ def fetch_repo_data(username: str, token: str):
 @st.cache_data(ttl=300)
 def fetch_contribution_data(username: str, token: str):
     """
-    Fetch contribution data from GitHub GraphQL API.
+    Fetch all-time contribution data from GitHub GraphQL API by iterating through years.
 
     Args:
         username (str): GitHub username.
         token (str): GitHub personal access token.
 
     Returns:
-        dict: JSON response from GitHub API containing contribution data or error message.
+        dict: Aggregated JSON-like response containing all-time contribution data.
     """
-    headers = {"Authorization": f"Bearer {token}"}
-    query = f"""
-    {{
-        user(login: "{username}") {{
-            contributionsCollection {{
-                restrictedContributionsCount
-                totalPullRequestContributions
-                totalIssueContributions
-                contributionCalendar {{
-                    totalContributions
-                    weeks {{
-                        contributionDays {{
-                            contributionCount
-                            date
-                        }}
-                    }}
-                }}
-            }}
-        }}
-    }}
-    """
+    # 1. Get user's creation date
+    user_info = fetch_user_data(username, token)
+    if "errors" in user_info:
+        return user_info
+    
     try:
-        response = requests.post(BASE_URL, json={"query": query}, headers=headers)
-        response.raise_for_status()
-        return response.json()
-    except requests.exceptions.RequestException as e:
+        created_at_str = user_info['data']['user']['createdAt']
+        created_at = datetime.strptime(created_at_str, "%Y-%m-%dT%H:%M:%SZ")
+        start_year = created_at.year
+        end_year = datetime.now().year
+        
+        all_weeks = []
+        total_contributions = 0
+        restricted_contributions = 0
+        total_commits = 0
+        total_prs = 0
+        total_issues = 0
+        
+        # 2. Fetch data year by year (GitHub GraphQL limit is 1 year per request)
+        for year in range(start_year, end_year + 1):
+            from_date = f"{year}-01-01"
+            to_date = f"{year}-12-31"
+            
+            year_data = fetch_data_for_duration(username, token, from_date, to_date)
+            
+            if "data" in year_data and year_data["data"]["user"]:
+                collection = year_data["data"]["user"]["contributionsCollection"]
+                calendar = collection["contributionCalendar"]
+                
+                all_weeks.extend(calendar.get("weeks", []))
+                total_contributions += calendar.get("totalContributions", 0)
+                restricted_contributions += collection.get("restrictedContributionsCount", 0)
+                total_commits += collection.get("totalCommitContributions", 0)
+                total_prs += collection.get("totalPullRequestContributions", 0)
+                total_issues += collection.get("totalIssueContributions", 0)
+            elif "errors" in year_data:
+                return year_data
+                
+        # 3. Return aggregated structure compatible with process_contribution_data
+        return {
+            "data": {
+                "user": {
+                    "contributionsCollection": {
+                        "restrictedContributionsCount": restricted_contributions,
+                        "totalCommitContributions": total_commits,
+                        "totalPullRequestContributions": total_prs,
+                        "totalIssueContributions": total_issues,
+                        "contributionCalendar": {
+                            "totalContributions": total_contributions,
+                            "weeks": all_weeks
+                        }
+                    }
+                }
+            }
+        }
+    except Exception as e:
         return {"errors": str(e)}
 
 

--- a/utils/fetch_github_data.py
+++ b/utils/fetch_github_data.py
@@ -161,8 +161,17 @@ def fetch_contribution_data(username: str, token: str):
         
         # 2. Fetch data year by year (GitHub GraphQL limit is 1 year per request)
         for year in range(start_year, end_year + 1):
-            from_date = f"{year}-01-01"
-            to_date = f"{year}-12-31"
+            # First year starts from account creation date
+            if year == start_year:
+                from_date = created_at.strftime("%Y-%m-%d")
+            else:
+                from_date = f"{year}-01-01"
+
+            # Last year ends at current date
+            if year == end_year:
+                to_date = datetime.now().strftime("%Y-%m-%d")
+            else:
+                to_date = f"{year}-12-31"
             
             year_data = fetch_data_for_duration(username, token, from_date, to_date)
             

--- a/utils/process_github_data.py
+++ b/utils/process_github_data.py
@@ -21,6 +21,10 @@ def process_contribution_data(data: dict):
         total_contributions = calendar.get('totalContributions', 0)
         private_contributions = contributions_collection.get('restrictedContributionsCount', 0)
         public_contributions = max(total_contributions - private_contributions, 0)
+        
+        total_commits = contributions_collection.get('totalCommitContributions', 0)
+        total_prs = contributions_collection.get('totalPullRequestContributions', 0)
+        total_issues = contributions_collection.get('totalIssueContributions', 0)
             
         # Calculate highest contribution
         highest_contribution, highest_contribution_date = get_highest_contribution(days)
@@ -38,6 +42,9 @@ def process_contribution_data(data: dict):
             "total_contributions": total_contributions,
             "public_contributions": public_contributions,
             "private_contributions": private_contributions,
+            "total_commits": total_commits,
+            "total_pullrequests": total_prs,
+            "total_issues": total_issues,
             "highest_contribution": highest_contribution,
             "highest_contribution_date": highest_contribution_date,
             "today_commits": today_commits,


### PR DESCRIPTION
## FEAT:
Fetches data right from creation date to present. This way all the stats(except prediction tab) now has updated numbers.

## Stat Changes:
### User Summary:
Total contributions, PRs and issue numbers change along with most productive day and streak.
before: 
<img width="1427" height="427" alt="image" src="https://github.com/user-attachments/assets/b3e9623d-8c5c-4ffd-8c21-6fe28f08fc59" />

after:
<img width="1295" height="482" alt="image" src="https://github.com/user-attachments/assets/d9f2e869-5afd-40ef-b14a-266f59d69091" />

### Contribution Graph
now shows contributions right from creation date to present
<img width="1327" height="677" alt="image" src="https://github.com/user-attachments/assets/972cd306-6091-4aeb-b693-4c7f3498b52c" />

### Visualizations
All visualizations now take all GitHub history instead of last 365 days.
Yearly stat now shows multiple years unlike before when it showed present and last year(incomplete data).
<img width="1306" height="597" alt="image" src="https://github.com/user-attachments/assets/4226337a-b6a4-4843-ac3d-02cb26f69ea6" />

<img width="1303" height="373" alt="image" src="https://github.com/user-attachments/assets/fd514426-f428-4b24-8bc0-ea215cf4e422" />